### PR TITLE
fix: add Open Graph meta tags and fix social sharing previews

### DIFF
--- a/blog/post.html
+++ b/blog/post.html
@@ -6,6 +6,15 @@
   <meta http-equiv="Pragma" content="no-cache" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Blog post by Sarvesh Bhatnagar" />
+  <meta property="og:title" content="Blog — Sarvesh Bhatnagar" />
+  <meta property="og:description" content="Blog post by Sarvesh Bhatnagar" />
+  <meta property="og:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
+  <meta property="og:site_name" content="Sarvesh Bhatnagar" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Blog — Sarvesh Bhatnagar" />
+  <meta name="twitter:description" content="Blog post by Sarvesh Bhatnagar" />
+  <meta name="twitter:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
   <title>Post — Sarvesh Bhatnagar</title>
   <link rel="stylesheet" href="../css/terminal.css" />
 </head>

--- a/blog/what-is-the-best-way-to-use-coding-agents.html
+++ b/blog/what-is-the-best-way-to-use-coding-agents.html
@@ -12,12 +12,12 @@
     <!-- Facebook and Twitter integration -->
     <meta property="og:title" content="What is the Best Way to Use Coding Agents?" />
     <meta property="og:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
-    <meta property="og:url" content="https://sarveshbhatnagar.com/blog/llms-and-cost.html" />
+    <meta property="og:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents.html" />
     <meta property="og:site_name" content="Sarvesh Bhatnagar" />
     <meta property="og:description" content="I have been experimenting with coding agents for a while, and in this post, I share some of my learnings, observations, and their quirks. Feel free to take a look, comment or share your ideas and thoughts about it with me." />
     <meta name="twitter:title" content="What is the Best Way to Use Coding Agents?" />
     <meta name="twitter:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
-    <meta name="twitter:url" content="https://sarveshbhatnagar.com/blog/llms-and-cost.html" />
+    <meta name="twitter:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents.html" />
     <meta name="twitter:card" content="summary" />
 
     <link href="https://fonts.googleapis.com/css?family=Space+Mono" rel="stylesheet">

--- a/js/terminal-blog.js
+++ b/js/terminal-blog.js
@@ -311,6 +311,17 @@ async function fetchPosts() {
       function renderPostBody(bodyHtml) {
         document.title = `${post.title} — Sarvesh Bhatnagar`;
 
+        // Update meta tags for social sharing (helps crawlers that execute JS)
+        const desc = post.excerpt || `${post.title} — Blog post by Sarvesh Bhatnagar`;
+        const url  = window.location.href;
+        const setMeta = (sel, val) => { const el = document.querySelector(sel); if (el) el.setAttribute('content', val); };
+        setMeta('meta[name="description"]',          desc);
+        setMeta('meta[property="og:title"]',         post.title);
+        setMeta('meta[property="og:description"]',   desc);
+        setMeta('meta[property="og:url"]',           url);
+        setMeta('meta[name="twitter:title"]',        post.title);
+        setMeta('meta[name="twitter:description"]',  desc);
+
         const tags = (post.tags || []).map(t => `<span class="tag">${t}</span>`).join('');
 
         container.innerHTML = `


### PR DESCRIPTION
## Summary

- **`blog/post.html`** — was missing all Open Graph and Twitter Card meta tags; social media scrapers (LinkedIn, Twitter) saw an empty shell with no preview
- **`blog/what-is-the-best-way-to-use-coding-agents.html`** — `og:url` and `twitter:url` both pointed to the wrong file (`llms-and-cost.html`)
- **`js/terminal-blog.js`** — `renderPostBody` now dynamically updates title, description, and URL meta tags when a post loads (helps JS-capable crawlers)

## Test plan

- [ ] Share `sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents.html` on LinkedIn — should show title, description, and image preview
- [ ] Validate with [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) or [OpenGraph.xyz](https://www.opengraph.xyz)
- [ ] Verify `post.html?id=...` has OG tags in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)