### PR TITLE
fix: embed static HTML for crawler compatibility (Medium import, SEO)

### DIFF
--- a/blog/blog.sh
+++ b/blog/blog.sh
@@ -66,7 +66,7 @@ description: A blog post by Sarvesh Bhatnagar about $title
 keywords: blog, thoughts, personal
 date: $date
 og_image: https://sarveshbhatnagar.com/images/user-3.jpg
-og_url: https://sarveshbhatnagar.com/blog/${filename}.html
+og_url: https://sarveshbhatnagar.com/blog/${filename}
 ---
 
 # $title

--- a/blog/build_blog.py
+++ b/blog/build_blog.py
@@ -85,7 +85,7 @@ class BlogGenerator:
         date = metadata.get("date", datetime.now().strftime("%B %d, %Y"))
         og_image = metadata.get("og_image", "")
         og_url = metadata.get(
-            "og_url", f"https://sarveshbhatnagar.com/blog/{filename}.html"
+            "og_url", f"https://sarveshbhatnagar.com/blog/{filename}"
         )
 
         # Replace placeholders in template

--- a/blog/markdown/what-is-the-best-way-to-use-coding-agents.md
+++ b/blog/markdown/what-is-the-best-way-to-use-coding-agents.md
@@ -4,7 +4,7 @@ description: I have been experimenting with coding agents for a while, and in th
 keywords: llm, cost, thoughts, agents, code
 date: April 14, 2026
 og_image: https://sarveshbhatnagar.com/images/user-3.jpg
-og_url: https://sarveshbhatnagar.com/blog/llms-and-cost.html
+og_url: https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents
 ---
 
 # Introduction

--- a/blog/templates/blog-template.html
+++ b/blog/templates/blog-template.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{TITLE}} - Sarvesh Bhatnagar</title>
+  <meta name="description" content="{{DESCRIPTION}}" />
+  <meta name="keywords" content="{{KEYWORDS}}" />
+  <meta name="author" content="Sarvesh Bhatnagar" />
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="{{OG_URL}}" />
+
+  <!-- Open Graph / Social sharing -->
+  <meta property="og:title" content="{{TITLE}}" />
+  <meta property="og:description" content="{{DESCRIPTION}}" />
+  <meta property="og:image" content="{{OG_IMAGE}}" />
+  <meta property="og:url" content="{{OG_URL}}" />
+  <meta property="og:site_name" content="Sarvesh Bhatnagar" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="{{TITLE}}" />
+  <meta name="twitter:description" content="{{DESCRIPTION}}" />
+  <meta name="twitter:image" content="{{OG_IMAGE}}" />
+  <meta name="twitter:url" content="{{OG_URL}}" />
+
+  <link rel="stylesheet" href="../css/terminal.css" />
+</head>
+<body>
+
+<!-- NAV -->
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-logo" aria-label="Home">
+      <span class="prompt">~/</span><span class="path">sb</span><span class="dollar">$</span>
+      <span class="cursor" aria-hidden="true"></span>
+    </a>
+    <div class="nav-links" role="list">
+      <a href="../index.html"    class="nav-link" data-page="/" role="listitem"><span class="cmd-prefix">&gt; </span>home</a>
+      <a href="../about.html"    class="nav-link" data-page="/about.html" role="listitem"><span class="cmd-prefix">&gt; </span>about</a>
+      <a href="../research.html" class="nav-link" data-page="/research.html" role="listitem"><span class="cmd-prefix">&gt; </span>research</a>
+      <a href="../projects.html" class="nav-link" data-page="/projects.html" role="listitem"><span class="cmd-prefix">&gt; </span>projects</a>
+      <a href="./"               class="nav-link active" data-page="/blog/" role="listitem"><span class="cmd-prefix">&gt; </span>blog</a>
+    </div>
+    <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+<div class="nav-mobile" id="nav-mobile" role="menu">
+  <a href="../index.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>home</a>
+  <a href="../about.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>about</a>
+  <a href="../research.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>research</a>
+  <a href="../projects.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>projects</a>
+  <a href="./"               class="nav-link active" role="menuitem"><span class="cmd-prefix">&gt; </span>blog</a>
+</div>
+
+<main id="main-content">
+  <section class="section" aria-label="Blog post">
+    <div class="container">
+      <article id="post-viewer" style="padding-top: var(--space-lg);">
+        <p><em>{{DATE}} — Sarvesh Bhatnagar</em></p>
+        {{CONTENT}}
+      </article>
+    </div>
+  </section>
+</main>
+
+<!-- FOOTER -->
+<footer class="footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-inner">
+      <div>
+        <div class="footer-brand"><span class="accent">~/sb$</span> Sarvesh Bhatnagar</div>
+        <div class="footer-copy">Developer · Researcher · Builder</div>
+      </div>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="../index.html">home</a>
+        <a href="../about.html">about</a>
+        <a href="../research.html">research</a>
+        <a href="../projects.html">projects</a>
+        <a href="./">blog</a>
+      </nav>
+    </div>
+  </div>
+</footer>
+
+<script src="../js/terminal-app.js"></script>
+</body>
+</html>

--- a/blog/understanding-yourself.html
+++ b/blog/understanding-yourself.html
@@ -5,19 +5,104 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Understanding Yourself - Sarvesh Bhatnagar</title>
   <meta name="description" content="A reflection on personal growth, finding your interests, and understanding what drives you forward in life." />
+  <meta name="keywords" content="personal growth, self reflection, career development, life choices" />
+  <meta name="author" content="Sarvesh Bhatnagar" />
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://sarveshbhatnagar.com/blog/understanding-yourself.html" />
+
+  <!-- Open Graph / Social sharing -->
   <meta property="og:title" content="Understanding Yourself" />
   <meta property="og:description" content="A reflection on personal growth, finding your interests, and understanding what drives you forward in life." />
   <meta property="og:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
   <meta property="og:url" content="https://sarveshbhatnagar.com/blog/understanding-yourself.html" />
   <meta property="og:site_name" content="Sarvesh Bhatnagar" />
   <meta property="og:type" content="article" />
-  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Understanding Yourself" />
   <meta name="twitter:description" content="A reflection on personal growth, finding your interests, and understanding what drives you forward in life." />
   <meta name="twitter:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
-  <script>window.location.replace('post.html?id=understanding-yourself');</script>
+  <meta name="twitter:url" content="https://sarveshbhatnagar.com/blog/understanding-yourself.html" />
+
+  <link rel="stylesheet" href="../css/terminal.css" />
 </head>
 <body>
-  <p>Redirecting… <a href="post.html?id=understanding-yourself">click here if not redirected</a></p>
+
+<!-- NAV -->
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-logo" aria-label="Home">
+      <span class="prompt">~/</span><span class="path">sb</span><span class="dollar">$</span>
+      <span class="cursor" aria-hidden="true"></span>
+    </a>
+    <div class="nav-links" role="list">
+      <a href="../index.html"    class="nav-link" data-page="/" role="listitem"><span class="cmd-prefix">&gt; </span>home</a>
+      <a href="../about.html"    class="nav-link" data-page="/about.html" role="listitem"><span class="cmd-prefix">&gt; </span>about</a>
+      <a href="../research.html" class="nav-link" data-page="/research.html" role="listitem"><span class="cmd-prefix">&gt; </span>research</a>
+      <a href="../projects.html" class="nav-link" data-page="/projects.html" role="listitem"><span class="cmd-prefix">&gt; </span>projects</a>
+      <a href="./"               class="nav-link active" data-page="/blog/" role="listitem"><span class="cmd-prefix">&gt; </span>blog</a>
+    </div>
+    <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+<div class="nav-mobile" id="nav-mobile" role="menu">
+  <a href="../index.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>home</a>
+  <a href="../about.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>about</a>
+  <a href="../research.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>research</a>
+  <a href="../projects.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>projects</a>
+  <a href="./"               class="nav-link active" role="menuitem"><span class="cmd-prefix">&gt; </span>blog</a>
+</div>
+
+<main id="main-content">
+  <section class="section" aria-label="Blog post">
+    <div class="container">
+      <article id="post-viewer" style="padding-top: var(--space-lg);">
+        <p><em>September 25, 2022 — Sarvesh Bhatnagar</em></p>
+        <h1 id="understanding-yourself">Understanding Yourself</h1>
+<p>So I was looking back at my life choices and was trying to understand why I am able to sail through without feeling burdened by the things I do. This mostly led myself to think around two main things, interest and not wanting to stay where I am.</p>
+<h2 id="finding-what-you-love">Finding What You Love</h2>
+<p>I will be honest, it was mainly luck on my part that I found what I love to do, although I was attracted to computers way before e.g. starting blogs to train people how to make computer virus, playing game, sometimes even trying to make games. Yes I enjoyed it but even with it I didn't really thought that I should pursue computer science.</p>
+<p>Far from that, I am not really interested in cyber security, or game development. It's just random work for me but it's a passion for some people and some people really enjoy that! So there goes my point, I was lucky. Instead of choosing to go for doctor, I went for an engineer (although I expressed my interest in becoming a doctor initially) AND I didn't really liked the studies that I did for getting into engineering. It's just I coincidentally took Computer Science in my junior college and there we go.</p>
+<h2 id="the-natural-fit">The Natural Fit</h2>
+<p>I got interested in it mainly at the time when I topped my junior college for Computer Science while almost failing for the other subjects. It's like this for me, if I don't like something no matter how attractive that might be, I won't do it. </p>
+<blockquote>
+<p>Digressing a bit since these are just my thoughts I am laying out here, I always tell my friends do not do anything if you don't find value in it. Do not do anything if you are not compensated enough for it. If you are getting undercompensated, you might do that for yourself instead of someone else.</p>
+</blockquote>
+<p>But yeah getting back to my point, I enjoyed computer science, I found it easy for me like natural.</p>
+<h2 id="the-drive-to-grow">The Drive to Grow</h2>
+<p>It was easy to understand different concepts in it, dig into different things and grasp new concepts. I was actively reading about different domains in computer science. So yeah, I think its very important to find something that you would love to do. You won't get bored doing.</p>
+<p>Another thing that compelled me for not staying complacent was the fact that I didn't want to be poor. Yeah, they are facts. I never got a bit jealous when looking at rich people earning more, I was like yeah they deserve it. They did it by themselves and this is how the world works and should work. So I didn't want to stay in the same position very badly.</p>
+<h2 id="impact-beyond-yourself">Impact Beyond Yourself</h2>
+<p>This thought process compelled me to understand how I can get out of my current state and make an impact on my life. This is good enough right? Well it becomes more complicated. When you try to grow yourself, like real growth you start thinking things through a different lens. Initially my thoughts were I'll earn lots of money that's it. But when you look deeper you find that your choices can impact peoples life. Your choices can impact how the world works, how people live and that is an important consideration to make.</p>
+<p>You need to become someone capable enough to be a support system for others not just for yourself. With that you will become more accomplished definitely but along that you will also help others to contribute to the society.</p>
+<h2 id="final-thoughts">Final Thoughts</h2>
+<p>I mean this is a very deep statement and this text is not a refined version of my thoughts, just some random draft about what I think, my personal opinions and not a burnished ones at that.</p>
+      </article>
+    </div>
+  </section>
+</main>
+
+<!-- FOOTER -->
+<footer class="footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-inner">
+      <div>
+        <div class="footer-brand"><span class="accent">~/sb$</span> Sarvesh Bhatnagar</div>
+        <div class="footer-copy">Developer · Researcher · Builder</div>
+      </div>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="../index.html">home</a>
+        <a href="../about.html">about</a>
+        <a href="../research.html">research</a>
+        <a href="../projects.html">projects</a>
+        <a href="./">blog</a>
+      </nav>
+    </div>
+  </div>
+</footer>
+
+<script src="../js/terminal-app.js"></script>
 </body>
 </html>

--- a/blog/what-is-the-best-way-to-use-coding-agents.html
+++ b/blog/what-is-the-best-way-to-use-coding-agents.html
@@ -4,26 +4,191 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>What is the Best Way to Use Coding Agents? - Sarvesh Bhatnagar</title>
-  <meta name="description" content="I've been using coding agents very actively — across personal projects, production systems, and research. Here are six key learnings on how to use them effectively." />
-  <meta name="keywords" content="sarvesh bhatnagar, bhatnagar sarvesh, sarvesh, introtoalgo, code logic, sarvesh rakesh bhatnagar, llm, cost, thoughts, agents, code" />
+  <meta name="description" content="I have been experimenting with coding agents for a while, and in this post, I share some of my learnings, observations, and their quirks. Feel free to take a look, comment or share your ideas and thoughts about it with me." />
+  <meta name="keywords" content="llm, cost, thoughts, agents, code" />
   <meta name="author" content="Sarvesh Bhatnagar" />
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents" />
 
   <!-- Open Graph / Social sharing -->
   <meta property="og:title" content="What is the Best Way to Use Coding Agents?" />
-  <meta property="og:image" content="https://sarveshbhatnagar.com/images/og-coding-agents.png" />
-  <meta property="og:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents.html" />
+  <meta property="og:description" content="I have been experimenting with coding agents for a while, and in this post, I share some of my learnings, observations, and their quirks. Feel free to take a look, comment or share your ideas and thoughts about it with me." />
+  <meta property="og:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
+  <meta property="og:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents" />
   <meta property="og:site_name" content="Sarvesh Bhatnagar" />
   <meta property="og:type" content="article" />
-  <meta property="og:description" content="I've been using coding agents very actively — across personal projects, production systems, and research. Here are six key learnings on how to use them effectively." />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="What is the Best Way to Use Coding Agents?" />
-  <meta name="twitter:image" content="https://sarveshbhatnagar.com/images/og-coding-agents.png" />
-  <meta name="twitter:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents.html" />
-  <meta name="twitter:description" content="I've been using coding agents very actively — across personal projects, production systems, and research. Here are six key learnings on how to use them effectively." />
+  <meta name="twitter:description" content="I have been experimenting with coding agents for a while, and in this post, I share some of my learnings, observations, and their quirks. Feel free to take a look, comment or share your ideas and thoughts about it with me." />
+  <meta name="twitter:image" content="https://sarveshbhatnagar.com/images/user-3.jpg" />
+  <meta name="twitter:url" content="https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents" />
 
-  <script>window.location.replace('post.html?id=what-is-the-best-way-to-use-coding-agents');</script>
+  <link rel="stylesheet" href="../css/terminal.css" />
 </head>
 <body>
-  <p>Redirecting… <a href="post.html?id=what-is-the-best-way-to-use-coding-agents">click here if not redirected</a></p>
+
+<!-- NAV -->
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a href="../index.html" class="nav-logo" aria-label="Home">
+      <span class="prompt">~/</span><span class="path">sb</span><span class="dollar">$</span>
+      <span class="cursor" aria-hidden="true"></span>
+    </a>
+    <div class="nav-links" role="list">
+      <a href="../index.html"    class="nav-link" data-page="/" role="listitem"><span class="cmd-prefix">&gt; </span>home</a>
+      <a href="../about.html"    class="nav-link" data-page="/about.html" role="listitem"><span class="cmd-prefix">&gt; </span>about</a>
+      <a href="../research.html" class="nav-link" data-page="/research.html" role="listitem"><span class="cmd-prefix">&gt; </span>research</a>
+      <a href="../projects.html" class="nav-link" data-page="/projects.html" role="listitem"><span class="cmd-prefix">&gt; </span>projects</a>
+      <a href="./"               class="nav-link active" data-page="/blog/" role="listitem"><span class="cmd-prefix">&gt; </span>blog</a>
+    </div>
+    <button class="nav-toggle" id="nav-toggle" aria-label="Toggle menu" aria-expanded="false">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+<div class="nav-mobile" id="nav-mobile" role="menu">
+  <a href="../index.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>home</a>
+  <a href="../about.html"    class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>about</a>
+  <a href="../research.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>research</a>
+  <a href="../projects.html" class="nav-link" role="menuitem"><span class="cmd-prefix">&gt; </span>projects</a>
+  <a href="./"               class="nav-link active" role="menuitem"><span class="cmd-prefix">&gt; </span>blog</a>
+</div>
+
+<main id="main-content">
+  <section class="section" aria-label="Blog post">
+    <div class="container">
+      <article id="post-viewer" style="padding-top: var(--space-lg);">
+        <p><em>April 14, 2026 — Sarvesh Bhatnagar</em></p>
+        <h1 id="introduction">Introduction</h1>
+<p>I’ve been using coding agents very actively still, nowhere near the <a href="https://www.businessinsider.com/jensen-huang-500k-engineers-250k-ai-tokens-nvidia-compute-2026-3">“$250K usage”</a> benchmark that recently came up in the industry headlines, it’s still significant in my view. Maybe I <em>am</em> the frog in the well but I’m learning, just as I did (and still do) as a software developer.</p>
+<p>You might wonder why I’m starting with cost. The reason is simple: the industry increasingly uses these numbers as a proxy for how deeply someone is engaging with LLMs—sometimes even more than actual impact. Initially, I thought this was a flawed metric. Now, I’m not so sure.</p>
+<p>It may not be perfect, but it <em>does</em> signal experimentation, curiosity, and iteration; qualities that matter when working with LLMs. I see myself as someone actively learning, experimenting, and building workflows to understand how this space is evolving and co-exist with it.</p>
+<p>With that context, here are some of my key learnings:</p>
+<ul>
+<li><strong>Learning 1:</strong> Use LLMs to explore, learn, and brainstorm heavily  </li>
+<li><strong>Learning 2:</strong> Don’t trust LLMs blindly: they hallucinate and make poor decisions  </li>
+<li><strong>Learning 3:</strong> Rein in generative LLMs with critical thinking and delegation  </li>
+<li><strong>Learning 4:</strong> Leverage community groundwork aggressively  </li>
+<li><strong>Learning 5:</strong> The developer’s role is shifting from implementer to reader and director  </li>
+<li><strong>Learning 6:</strong> Make peace with delegation  </li>
+</ul>
+<hr />
+<h1 id="what-have-i-been-doing">What Have I Been Doing?</h1>
+<p>Over the past year, I’ve gone through multiple phases—starting as a skeptic (back when coding agents like GitHub Copilot were just emerging), then becoming a fan, then skeptical again, and now settling somewhere in between.</p>
+<p>This back-and-forth came from hands-on experience. I’ve used coding agents across:</p>
+<ul>
+<li>Personal projects  </li>
+<li>Production systems  </li>
+<li>Learning and research  </li>
+<li>General problem-solving  </li>
+</ul>
+<p>One thing I’ve realized: the real bottleneck is no longer writing code—it’s <strong>processing and validating information</strong>. It’s mentally taxing to read, verify, and reason through everything these systems generate. Sometimes I trust too easily; other times I overanalyze.</p>
+<p>That balance is still something I’m figuring out.</p>
+<hr />
+<h2 id="learning-1-use-llms-to-explore-learn-and-brainstorm-heavily">Learning 1: Use LLMs to Explore, Learn, and Brainstorm Heavily</h2>
+<p>LLMs are excellent for exploration. They help you:</p>
+<ul>
+<li>Generate ideas  </li>
+<li>Identify patterns  </li>
+<li>Explore solution spaces quickly  </li>
+</ul>
+<p>However, they are still limited by their training data. They tend to stay within the setting, e.g. if your project is bad, it will keep going down the rabid hole. I have found that providing extra outside samples have worked at times for it to think outside at times.</p>
+<p>Remember: LLMs are token predictors. Better input → better output.</p>
+<hr />
+<h2 id="learning-2-dont-trust-llms-blindly">Learning 2: Don’t Trust LLMs Blindly</h2>
+<p>LLMs can and will make bad decisions.</p>
+<p>I learned this the hard way. In one project, I relied too heavily on an LLM for design decisions. It made fragile architectures which had poor extensibility and constant regressions (fixing one thing would break another). For this, active reading helped. My general workflow currently is as follows - I delegate completely, look for key flow on how things are going and see if the flow has flaws, if it does I tell the agent to change it and fix the same, else I do a second pass review with more in depth take.</p>
+<hr />
+<h2 id="learning-3-rein-in-generative-llms-with-critical-thinking-and-delegation">Learning 3: Rein in Generative LLMs with Critical Thinking and Delegation</h2>
+<p>LLMs generate—they don’t reason deeply.</p>
+<p>One approach that worked well for me:</p>
+<ul>
+<li>Use <strong>multiple agents</strong>  </li>
+<li>Let independent agents review each other’s output  </li>
+<li>Avoid sharing full context across all agents  </li>
+</ul>
+<p>This often surfaces flaws in reasoning.</p>
+<p>It’s similar to the concept of extended cognition—using external systems to improve thinking. Here, LLMs become <em>thinking collaborators</em>, not just tools.</p>
+<p>But the key responsibility still lies with you:</p>
+<ul>
+<li>Understand what’s being generated  </li>
+<li>Evaluate trade-offs  </li>
+<li>Anticipate future issues  </li>
+</ul>
+<hr />
+<h2 id="learning-4-use-community-groundwork-heavily">Learning 4: Use Community Groundwork Heavily</h2>
+<p>The community is moving incredibly fast:</p>
+<ul>
+<li>New tools  </li>
+<li>New workflows  </li>
+<li>New abstractions  </li>
+</ul>
+<p>You don’t need to reinvent everything.</p>
+<p>Actively:</p>
+<ul>
+<li>Follow what others are building  </li>
+<li>Reuse proven patterns  </li>
+<li>Adapt instead of starting from scratch </li>
+<li>Starting from scratch at times is okay for better exploration (personal thoughts)</li>
+</ul>
+<hr />
+<h2 id="learning-5-the-developers-role-is-changing">Learning 5: The Developer’s Role Is Changing</h2>
+<p>The role is shifting from:</p>
+<ul>
+<li><strong>Implementer → Reader + Director</strong></li>
+</ul>
+<p>You now:</p>
+<ul>
+<li>Read large volumes of generated code  </li>
+<li>Validate correctness and design  </li>
+<li>Guide systems rather than build everything manually  </li>
+</ul>
+<p>The bottleneck is no longer typing—it’s <strong>thinking and decision-making</strong>.I believe this has been the case, now or in the past as well. Developer's job has always been thinking deeply.</p>
+<hr />
+<h2 id="learning-6-make-peace-with-delegation">Learning 6: Make Peace with Delegation</h2>
+<p>This is the hardest but most important shift.</p>
+<p>To truly benefit from LLMs:</p>
+<ul>
+<li>Delegate entire tasks—not just small pieces  </li>
+<li>Let agents build end-to-end systems  </li>
+<li>Iterate afterward  </li>
+</ul>
+<p>Yes, they will make mistakes. That’s expected.</p>
+<p>But if you:</p>
+<ul>
+<li>Review carefully  </li>
+<li>Understand deeply  </li>
+<li>Refactor where needed  </li>
+</ul>
+<p>You’ll still move significantly faster. If you don’t fully delegate, you’re not unlocking their real value—you’re just using them as autocomplete. And that won’t differentiate you.</p>
+<hr />
+<h1 id="final-thoughts">Final Thoughts</h1>
+<p>LLMs are not magic—they are powerful but flawed collaborators. We will have to learn to co-exist by being better thinkers and know when to trust and when not to.</p>
+      </article>
+    </div>
+  </section>
+</main>
+
+<!-- FOOTER -->
+<footer class="footer" role="contentinfo">
+  <div class="container">
+    <div class="footer-inner">
+      <div>
+        <div class="footer-brand"><span class="accent">~/sb$</span> Sarvesh Bhatnagar</div>
+        <div class="footer-copy">Developer · Researcher · Builder</div>
+      </div>
+      <nav class="footer-links" aria-label="Footer navigation">
+        <a href="../index.html">home</a>
+        <a href="../about.html">about</a>
+        <a href="../research.html">research</a>
+        <a href="../projects.html">projects</a>
+        <a href="./">blog</a>
+      </nav>
+    </div>
+  </div>
+</footer>
+
+<script src="../js/terminal-app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Replaced JS-redirect blog pages with fully static HTML so server-side crawlers (Medium import, Googlebot, social card scrapers) can read post content without executing JavaScript
- Added `blog/templates/blog-template.html` — new build template that embeds article content directly in the page with proper nav/footer
- Fixed `build_blog.py` and `blog.sh` to generate clean canonical URLs (no `.html` suffix) by default
- Fixed wrong `og_url` in the coding-agents post frontmatter (was pointing to a different post)
- Rebuilt both existing posts (`understanding-yourself`, `what-is-the-best-way-to-use-coding-agents`) with the new template

## Root cause

The old template used `window.location.replace('post.html?id=...')` and `post.html` rendered content via `terminal-blog.js` into an empty `#post-viewer` div. Any crawler that doesn't run JS saw an empty page — this is why Medium's "Import a story" feature failed.

## Test plan

- [ ] Visit a blog post URL — page renders with content visible (no blank flash or redirect)
- [ ] Import `https://sarveshbhatnagar.com/blog/what-is-the-best-way-to-use-coding-agents` on Medium — content should be detected
- [ ] Run `./blog/blog.sh build` — new posts generate static HTML from the template
- [ ] Check `og:url` and `<link rel="canonical">` in generated HTML use clean URLs (no `.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)