### PR TITLE
feat: URL import, GitHub publish, and code block rendering

### DIFF
--- a/blog/write.html
+++ b/blog/write.html
@@ -6,6 +6,98 @@
   <meta name="description" content="Blog writer — create and format posts for Sarvesh Bhatnagar's portfolio." />
   <title>Write Post — Sarvesh Bhatnagar</title>
   <link rel="stylesheet" href="../css/terminal.css" />
+  <style>
+    .import-section {
+      display: flex;
+      flex-direction: column;
+      gap: .6rem;
+      margin-bottom: 2rem;
+      padding: 1rem 1.25rem;
+      border: 1px solid var(--glass-border);
+      border-radius: .75rem;
+      background: rgba(255,255,255,.03);
+    }
+    .import-label {
+      font-family: var(--font-head);
+      font-size: .75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .07em;
+      color: var(--text-muted);
+    }
+    .import-row {
+      display: flex;
+      gap: .5rem;
+    }
+    .import-row .glass-input {
+      flex: 1;
+      min-width: 0;
+    }
+    .import-row .btn {
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .import-status {
+      font-size: .8rem;
+      font-family: var(--font-mono);
+      min-height: 1.2em;
+      color: var(--text-faint);
+    }
+    .import-status[data-type="error"]   { color: #f87171; }
+    .import-status[data-type="success"] { color: var(--green); }
+    .import-status[data-type="info"]    { color: var(--cyan); }
+
+    /* GitHub publish section */
+    .publish-section {
+      margin-top: 2rem;
+      padding: 1.25rem;
+      border: 1px solid var(--glass-border);
+      border-radius: .75rem;
+      background: rgba(255,255,255,.03);
+      display: flex;
+      flex-direction: column;
+      gap: .75rem;
+    }
+    .publish-section-label {
+      font-family: var(--font-head);
+      font-size: .75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .07em;
+      color: var(--text-muted);
+    }
+    .token-row {
+      display: flex;
+      gap: .5rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+    .token-row .glass-input {
+      flex: 1;
+      min-width: 0;
+      font-family: var(--font-mono);
+      font-size: .8rem;
+    }
+    #gh-token-status {
+      font-size: .78rem;
+      font-family: var(--font-mono);
+      color: var(--text-faint);
+    }
+    #gh-token-status[data-type="success"] { color: var(--green); }
+    #gh-token-status[data-type="error"]   { color: #f87171; }
+    #gh-token-status[data-type="warn"]    { color: #fbbf24; }
+    #publish-status {
+      font-size: .8rem;
+      font-family: var(--font-mono);
+      min-height: 1.2em;
+      color: var(--text-faint);
+      word-break: break-all;
+    }
+    #publish-status[data-type="success"] { color: var(--green); }
+    #publish-status[data-type="error"]   { color: #f87171; }
+    #publish-status[data-type="info"]    { color: var(--cyan); }
+    #publish-status a { color: inherit; text-decoration: underline; }
+  </style>
 </head>
 <body>
 
@@ -48,6 +140,23 @@
           </p>
         </div>
 
+        <!-- Import from URL -->
+        <div class="import-section reveal">
+          <div class="import-label">Import from URL</div>
+          <div class="import-row">
+            <input
+              type="url"
+              id="import-url"
+              class="glass-input"
+              placeholder="https://medium.com/…"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button id="import-btn" class="btn btn-cyan btn-sm">import</button>
+          </div>
+          <div id="import-status" class="import-status"></div>
+        </div>
+
         <!-- Instructional notice -->
         <div class="writer-notice" role="note">
           <strong>How to publish:</strong> Fill in the fields below, write your post in markdown,
@@ -70,6 +179,16 @@
             <label for="post-tags">Tags</label>
             <input type="text" id="post-tags" class="glass-input"
                    placeholder="tag1, tag2, tag3" autocomplete="off" />
+          </div>
+          <div class="field-group">
+            <label for="post-author">Original Author <span style="color:var(--text-faint);font-weight:400">(optional — for imported posts)</span></label>
+            <input type="text" id="post-author" class="glass-input"
+                   placeholder="e.g. Jane Doe" autocomplete="off" />
+          </div>
+          <div class="field-group">
+            <label for="post-source">Source URL <span style="color:var(--text-faint);font-weight:400">(optional — original article link)</span></label>
+            <input type="url" id="post-source" class="glass-input"
+                   placeholder="https://medium.com/…" autocomplete="off" />
           </div>
         </div>
 
@@ -118,6 +237,32 @@
           </a>
         </div>
 
+        <!-- Publish to GitHub -->
+        <div class="publish-section">
+          <div class="publish-section-label">Publish to GitHub</div>
+
+          <!-- Token setup -->
+          <div class="token-row">
+            <input
+              type="password"
+              id="gh-token-input"
+              class="glass-input"
+              placeholder="GitHub PAT (contents:write) — stored in localStorage"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button id="gh-save-token" class="btn btn-outline btn-sm">save</button>
+            <button id="gh-clear-token" class="btn btn-ghost btn-sm" style="display:none">clear</button>
+          </div>
+          <div id="gh-token-status"></div>
+
+          <!-- Publish action -->
+          <div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
+            <button id="publish-btn" class="btn btn-primary">Publish to GitHub</button>
+          </div>
+          <div id="publish-status"></div>
+        </div>
+
         <!-- JSON output -->
         <div class="json-output-section">
           <div style="font-family:var(--font-head);font-size:.85rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.06em;margin-bottom:.75rem">
@@ -157,5 +302,10 @@
 
 <script src="../js/terminal-app.js"></script>
 <script src="../js/terminal-blog.js"></script>
+<!-- Import feature dependencies -->
+<script src="https://cdn.jsdelivr.net/npm/@mozilla/readability@0.5.0/Readability.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/turndown@7.2.0/dist/turndown.js"></script>
+<script src="../js/blog-import.js"></script>
+<script src="../js/github-publish.js"></script>
 </body>
 </html>

--- a/css/terminal.css
+++ b/css/terminal.css
@@ -347,9 +347,20 @@ pre code { background: none; border: none; padding: 0; color: var(--text); }
 .post-content li { margin-bottom: 0.4em; color: var(--text); } .post-content li::marker { color: var(--green); }
 .post-content blockquote { border-left: 3px solid var(--green); padding: var(--space-sm) var(--space-md); color: var(--text-muted); background: var(--surface-alt); border-radius: 0 4px 4px 0; margin: var(--space-md) 0; font-style: italic; }
 .post-content a { color: var(--cyan); } .post-content a:hover { color: var(--green); }
+.post-source-attrib { font-size: .78rem; font-family: var(--font-mono); color: var(--text-faint); border-left: 2px solid var(--border-hover); padding: .3em .75em; margin-bottom: var(--space-lg); }
+.post-source-attrib a { color: var(--text-muted); } .post-source-attrib a:hover { color: var(--cyan); }
 .post-content strong { color: var(--amber); font-weight: 700; } .post-content em { color: var(--text-muted); font-style: italic; }
 .post-content hr { border: none; border-top: 1px solid var(--border); margin: var(--space-lg) 0; }
-.post-content pre { margin: var(--space-md) 0; }
+/* Code block wrapper injected by enhanceCodeBlocks() */
+.post-code-block { margin: var(--space-lg) 0; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }
+.post-code-header { display: flex; align-items: center; justify-content: space-between; background: var(--surface-alt); border-bottom: 1px solid var(--border); padding: .35em var(--space-md); }
+.post-code-lang { font-family: var(--font-mono); font-size: .7rem; font-weight: 600; color: var(--amber); text-transform: uppercase; letter-spacing: .05em; }
+.post-code-copy { background: none; border: none; color: var(--text-faint); cursor: pointer; font-family: var(--font-mono); font-size: .72rem; padding: 0; transition: color .15s; }
+.post-code-copy:hover { color: var(--green); }
+/* pre inside .post-code-block loses its own border/radius/margin — the wrapper owns those */
+.post-code-block pre { margin: 0; border: none; border-radius: 0; }
+/* standalone pre outside a wrapper (e.g. write.html preview) keeps normal spacing */
+.post-content pre:not(.post-code-block > pre) { margin: var(--space-md) 0; }
 
 /* -------------------------------------------------------
    15. Blog Writer / Editor

--- a/js/blog-import.js
+++ b/js/blog-import.js
@@ -1,0 +1,241 @@
+/**
+ * blog-import.js
+ * Import a blog post from any URL into the write.html editor.
+ *
+ * Dependencies (loaded before this script in write.html):
+ *   - Readability.js  (@mozilla/readability)
+ *   - TurndownService (turndown)
+ *
+ * Medium URLs are routed through freedium.cfd which server-renders
+ * Medium articles as clean HTML that Readability can parse properly.
+ */
+
+(function initBlogImport() {
+  const importBtn = document.getElementById('import-btn');
+  const urlInput  = document.getElementById('import-url');
+  const statusEl  = document.getElementById('import-status');
+
+  if (!importBtn || !urlInput) return;
+
+  function setStatus(msg, type) {
+    statusEl.textContent = msg;
+    statusEl.dataset.type = type || '';
+  }
+
+  function setLoading(on) {
+    importBtn.disabled = on;
+    importBtn.textContent = on ? 'importing…' : 'import';
+    urlInput.disabled = on;
+  }
+
+  /**
+   * Rewrite Medium article URLs to scribe.rip, which server-renders Medium
+   * articles as clean HTML without Cloudflare bot protection.
+   *
+   * Medium URL patterns:
+   *   https://medium.com/@user/slug-hash          → scribe.rip/@user/slug-hash
+   *   https://medium.com/publication/slug-hash    → scribe.rip/publication/slug-hash
+   *   https://pub.medium.com/slug-hash            → scribe.rip/slug-hash
+   */
+  function resolveFetchUrl(rawUrl) {
+    try {
+      const u = new URL(rawUrl);
+      if (u.hostname === 'medium.com' || u.hostname.endsWith('.medium.com')) {
+        const path = u.pathname; // e.g. /gitconnected/slug or /@user/slug
+        return { fetchUrl: 'https://scribe.rip' + path, via: 'scribe.rip' };
+      }
+    } catch (_) {}
+    return { fetchUrl: rawUrl, via: null };
+  }
+
+  /** Try a single fetch and return text, or throw. */
+  async function tryFetch(url, label, timeoutMs = 15000) {
+    setStatus('Trying ' + label + '…', 'info');
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) throw new Error(label + ' returned HTTP ' + res.status);
+    return res.text();
+  }
+
+  /** Fetch through proxies, trying each in order. */
+  async function fetchViaProxy(targetUrl, tryDirect) {
+    // 1. Local Python proxy (most reliable — run proxy_server.py alongside the dev server)
+    const localProxy = {
+      label: 'local proxy',
+      url: () => 'http://localhost:8002/proxy?url=' + encodeURIComponent(targetUrl),
+    };
+
+    // 2. For Freedium URLs try a direct browser fetch — they may allow CORS
+    if (tryDirect) {
+      try {
+        const html = await tryFetch(targetUrl, 'Freedium direct', 10000);
+        if (html) return html;
+      } catch (_) { /* fall through */ }
+    }
+
+    // 3. Public fallback proxies (unreliable — used only when local proxy isn't running)
+    const publicProxies = [
+      { label: 'codetabs',    url: () => 'https://api.codetabs.com/v1/proxy?quest=' + encodeURIComponent(targetUrl) },
+      { label: 'allorigins',  url: () => 'https://api.allorigins.win/raw?url='       + encodeURIComponent(targetUrl) },
+      { label: 'corsproxy.io',url: () => 'https://corsproxy.io/?url='                + encodeURIComponent(targetUrl) },
+    ];
+
+    let lastErr;
+    for (const proxy of [localProxy, ...publicProxies]) {
+      try {
+        const html = await tryFetch(proxy.url(), proxy.label);
+        if (html) return html;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    throw new Error(
+      'All proxies failed. Run `python3 proxy_server.py` in your project folder for reliable imports.'
+    );
+  }
+
+  /** Strip Turndown noise: excessive blank lines, trailing whitespace. */
+  function cleanMarkdown(md) {
+    return md
+      .replace(/\n{3,}/g, '\n\n')   // collapse 3+ blank lines → 2
+      .replace(/[ \t]+$/gm, '')      // strip trailing spaces per line
+      .trim();
+  }
+
+  async function doImport() {
+    const rawUrl = urlInput.value.trim();
+    if (!rawUrl) { setStatus('Paste a URL first.', 'error'); return; }
+
+    let targetUrl;
+    try { targetUrl = new URL(rawUrl); } catch (_) {
+      setStatus("That doesn't look like a valid URL.", 'error'); return;
+    }
+    if (!['http:', 'https:'].includes(targetUrl.protocol)) {
+      setStatus('Only http/https URLs are supported.', 'error'); return;
+    }
+    if (!window.Readability) {
+      setStatus('Readability not loaded — check your connection.', 'error'); return;
+    }
+    if (!window.TurndownService) {
+      setStatus('Turndown not loaded — check your connection.', 'error'); return;
+    }
+
+    setLoading(true);
+
+    const { fetchUrl, via } = resolveFetchUrl(rawUrl);
+    if (via) setStatus('Medium detected — routing through ' + via + '…', 'info');
+
+    // 1. Fetch
+    let html;
+    try {
+      html = await fetchViaProxy(fetchUrl, false);
+    } catch (err) {
+      setStatus(err.message, 'error');
+      setLoading(false);
+      return;
+    }
+
+    // 2. Extract with Readability
+    setStatus('Extracting article…', 'info');
+    let article;
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+
+      // Resolve relative URLs against the *original* URL (not Freedium)
+      const base = doc.createElement('base');
+      base.href = rawUrl;
+      doc.head.prepend(base);
+
+      // Strip Freedium / Medium chrome before Readability sees it
+      doc.querySelectorAll(
+        '.freedium-header, .freedium-footer, .metabar, nav, header, footer, ' +
+        '[data-testid="headerStickyContainer"], [data-testid="audioPlayButton"], ' +
+        '.pw-responses-container'
+      ).forEach(el => el.remove());
+
+      article = new Readability(doc, { charThreshold: 100 }).parse();
+      if (!article?.content) throw new Error('No article content found on that page.');
+    } catch (err) {
+      setStatus('Extraction failed: ' + err.message, 'error');
+      setLoading(false);
+      return;
+    }
+
+    // 3. Convert HTML → Markdown
+    setStatus('Converting to Markdown…', 'info');
+    let markdown;
+    try {
+      const td = new TurndownService({
+        headingStyle:     'atx',
+        hr:               '---',
+        bulletListMarker: '-',
+        codeBlockStyle:   'fenced',
+        fence:            '```',
+      });
+
+      // Keep tables
+      if (window.turndownPluginGfm) {
+        td.use(turndownPluginGfm.gfm);
+      }
+
+      // Drop decorative / nav elements
+      td.remove([
+        'figure > figcaption + *', // duplicate caption elements
+        'button', 'nav', 'aside',
+        '[role="navigation"]', '[role="banner"]',
+        '.related-posts', '.comments', '.responses',
+      ]);
+
+      // Pre-process: wrap bare <pre> (no <code> child) in <code> so Turndown
+      // recognises them as fenced code blocks instead of plain paragraphs.
+      // scribe.rip (and many sites) use <pre>text</pre> without a <code> child.
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = article.content;
+      tempDiv.querySelectorAll('pre').forEach(pre => {
+        if (!pre.querySelector('code')) {
+          const code = document.createElement('code');
+          code.textContent = pre.textContent; // textContent decodes HTML entities
+          pre.innerHTML = '';
+          pre.appendChild(code);
+        }
+      });
+
+      // Collapse multiple consecutive blank lines Turndown sometimes emits
+      markdown = cleanMarkdown(td.turndown(tempDiv.innerHTML));
+    } catch (err) {
+      setStatus('Markdown conversion failed: ' + err.message, 'error');
+      setLoading(false);
+      return;
+    }
+
+    // 4. Populate form fields
+    const titleEl  = document.getElementById('post-title');
+    const authorEl = document.getElementById('post-author');
+    const sourceEl = document.getElementById('post-source');
+    const editorEl = document.getElementById('md-editor');
+
+    if (titleEl && article.title) titleEl.value = article.title.trim();
+
+    // Readability exposes the byline (author name) when it finds it
+    if (authorEl && article.byline) authorEl.value = article.byline.trim();
+
+    // Always record the original URL as source
+    if (sourceEl) sourceEl.value = rawUrl;
+
+    if (editorEl) {
+      editorEl.value = markdown;
+      editorEl.dispatchEvent(new Event('input')); // refresh live preview
+    }
+
+    setLoading(false);
+    setStatus(
+      'Imported "' + (article.title || 'article') + '"' +
+      (article.byline ? ' by ' + article.byline : '') +
+      '. Review content, add tags, then publish.',
+      'success'
+    );
+  }
+
+  importBtn.addEventListener('click', doImport);
+  urlInput.addEventListener('keydown', e => { if (e.key === 'Enter') doImport(); });
+})();

--- a/js/github-publish.js
+++ b/js/github-publish.js
@@ -1,0 +1,185 @@
+/**
+ * github-publish.js
+ * Publishes a post entry directly to blog/posts/posts.json via the GitHub Contents API.
+ *
+ * Requires a GitHub Personal Access Token (PAT) with `contents: write` on this repo.
+ * The token is stored in localStorage — never sent anywhere except api.github.com.
+ */
+
+(function initGitHubPublisher() {
+  const OWNER      = 'sarveshbhatnagar';
+  const REPO       = 'profile';
+  const BRANCH     = 'master';
+  const POSTS_PATH = 'blog/posts/posts.json';
+  const TOKEN_KEY  = 'gh_pat_blog';
+  const API_BASE   = 'https://api.github.com';
+
+  /* ---- Token storage ---- */
+  function getToken()      { return localStorage.getItem(TOKEN_KEY) || ''; }
+  function saveToken(t)    { localStorage.setItem(TOKEN_KEY, t.trim()); }
+  function clearToken()    { localStorage.removeItem(TOKEN_KEY); }
+
+  /* ---- Slug helper ---- */
+  function toSlug(str) {
+    return str.toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .trim();
+  }
+
+  /* ---- GitHub API helpers ---- */
+  function apiHeaders(token) {
+    return {
+      'Authorization':        'Bearer ' + token,
+      'Accept':               'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type':         'application/json',
+    };
+  }
+
+  async function readPostsJson(token) {
+    const res = await fetch(
+      `${API_BASE}/repos/${OWNER}/${REPO}/contents/${POSTS_PATH}?ref=${BRANCH}`,
+      { headers: apiHeaders(token) }
+    );
+    if (res.status === 401) throw new Error('Invalid token — check your PAT.');
+    if (res.status === 403) throw new Error('Token lacks write permission on this repo.');
+    if (!res.ok) throw new Error('Could not read posts.json (' + res.status + ').');
+
+    const json = await res.json();
+    const content = JSON.parse(
+      decodeURIComponent(escape(atob(json.content.replace(/\n/g, ''))))
+    );
+    return { sha: json.sha, posts: content };
+  }
+
+  async function writePostsJson(token, sha, posts, commitMsg) {
+    const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(posts, null, 2))));
+    const res = await fetch(
+      `${API_BASE}/repos/${OWNER}/${REPO}/contents/${POSTS_PATH}`,
+      {
+        method: 'PUT',
+        headers: apiHeaders(token),
+        body: JSON.stringify({
+          message: commitMsg,
+          content: encoded,
+          sha,
+          branch: BRANCH,
+        }),
+      }
+    );
+    if (res.status === 401) throw new Error('Invalid token — check your PAT.');
+    if (res.status === 403) throw new Error('Token lacks write permission on this repo.');
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || 'GitHub API error (' + res.status + ').');
+    }
+    return res.json();
+  }
+
+  /* ---- Main publish function ---- */
+  async function publishPost({ title, date, tags, markdown, author, source }) {
+    const token = getToken();
+    if (!token) throw new Error('No GitHub token saved. Enter your PAT first.');
+
+    const slug    = toSlug(title) || 'untitled-post';
+    const html    = window.mdToHtml ? window.mdToHtml(markdown) : markdown;
+    const rawText = markdown.replace(/^#+\s*/gm, '').replace(/[*_`\[\]]/g, '');
+    const firstPara = rawText.split(/\n\n/)[0].replace(/\n/g, ' ').trim();
+    const excerpt = firstPara.length > 160 ? firstPara.slice(0, 157) + '...' : firstPara;
+
+    const entry = { id: slug, title, date, excerpt, content: html, tags };
+    if (author) entry.author = author;
+    if (source) entry.source = source;
+
+    const { sha, posts } = await readPostsJson(token);
+    const updated = [entry, ...posts.filter(p => p.id !== slug)];
+    await writePostsJson(token, sha, updated, `blog: add "${title}"`);
+
+    return { slug, url: `https://sarveshbhatnagar.com/blog/post.html?id=${slug}` };
+  }
+
+  /* ---- UI wiring ---- */
+  function initUI() {
+    const tokenInput   = document.getElementById('gh-token-input');
+    const saveTokenBtn = document.getElementById('gh-save-token');
+    const clearTokenBtn= document.getElementById('gh-clear-token');
+    const tokenStatus  = document.getElementById('gh-token-status');
+    const publishBtn   = document.getElementById('publish-btn');
+    const publishStatus= document.getElementById('publish-status');
+
+    if (!publishBtn) return;
+
+    function refreshTokenState() {
+      const stored = getToken();
+      if (stored) {
+        tokenStatus.textContent  = '// token saved';
+        tokenStatus.dataset.type = 'success';
+        if (tokenInput)    tokenInput.value = '';
+        if (clearTokenBtn) clearTokenBtn.style.display = '';
+        if (saveTokenBtn)  saveTokenBtn.textContent = 'update';
+      } else {
+        tokenStatus.textContent  = '// no token — enter a PAT with contents:write';
+        tokenStatus.dataset.type = 'warn';
+        if (clearTokenBtn) clearTokenBtn.style.display = 'none';
+        if (saveTokenBtn)  saveTokenBtn.textContent = 'save';
+      }
+    }
+
+    if (saveTokenBtn) {
+      saveTokenBtn.addEventListener('click', () => {
+        const val = tokenInput?.value.trim();
+        if (!val) { tokenStatus.textContent = 'Paste your token first.'; tokenStatus.dataset.type = 'error'; return; }
+        saveToken(val);
+        refreshTokenState();
+      });
+    }
+
+    if (clearTokenBtn) {
+      clearTokenBtn.addEventListener('click', () => {
+        clearToken();
+        refreshTokenState();
+      });
+    }
+
+    publishBtn.addEventListener('click', async () => {
+      const title    = document.getElementById('post-title')?.value.trim();
+      const date     = document.getElementById('post-date')?.value.trim();
+      const rawTags  = document.getElementById('post-tags')?.value.trim();
+      const markdown = document.getElementById('md-editor')?.value.trim();
+      const author   = document.getElementById('post-author')?.value.trim();
+      const source   = document.getElementById('post-source')?.value.trim();
+
+      if (!title)    { publishStatus.textContent = 'Add a title first.';    publishStatus.dataset.type = 'error'; return; }
+      if (!markdown) { publishStatus.textContent = 'Write some content first.'; publishStatus.dataset.type = 'error'; return; }
+
+      const tags = rawTags ? rawTags.split(',').map(t => t.trim()).filter(Boolean) : [];
+
+      publishBtn.disabled = true;
+      publishBtn.textContent = 'publishing…';
+      publishStatus.textContent = 'Committing to GitHub…';
+      publishStatus.dataset.type = 'info';
+
+      try {
+        const result = await publishPost({ title, date, tags, markdown, author, source });
+        publishStatus.innerHTML =
+          '// published! Live in ~30 s → <a href="' + result.url + '" target="_blank" rel="noopener">' + result.url + '</a>';
+        publishStatus.dataset.type = 'success';
+      } catch (err) {
+        publishStatus.textContent = err.message;
+        publishStatus.dataset.type = 'error';
+      } finally {
+        publishBtn.disabled = false;
+        publishBtn.textContent = 'Publish to GitHub';
+      }
+    });
+
+    refreshTokenState();
+  }
+
+  document.addEventListener('DOMContentLoaded', initUI);
+
+  // Expose for console debugging
+  window.GitHubPublisher = { getToken, saveToken, clearToken };
+})();

--- a/js/terminal-blog.js
+++ b/js/terminal-blog.js
@@ -32,54 +32,62 @@ function postsJsonUrl() {
 function mdToHtml(md) {
   if (!md) return '';
 
-  let html = md
+  // Phase 1: Extract fenced code blocks as placeholders so their content
+  // is never touched by heading/list/paragraph transforms.
+  const codeBlocks = [];
+  let s = md.replace(/```(\w*)\r?\n([\s\S]*?)```/g, (_, lang, code) => {
+    const idx = codeBlocks.length;
+    const escaped = code.trim()
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    codeBlocks.push(`<pre><code class="lang-${lang || 'text'}">${escaped}</code></pre>`);
+    return `\x00BLOCK${idx}\x00`;
+  });
+
+  // Phase 2: HTML-encode remaining text (code blocks already encoded above)
+  s = s
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // Fenced code blocks
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) =>
-    `<pre><code class="lang-${lang || 'text'}">${code.trim()}</code></pre>`
-  );
-
-  // Headings
-  html = html.replace(/^###### (.+)$/gm, '<h6>$1</h6>');
-  html = html.replace(/^##### (.+)$/gm,  '<h5>$1</h5>');
-  html = html.replace(/^#### (.+)$/gm,   '<h4>$1</h4>');
-  html = html.replace(/^### (.+)$/gm,    '<h3>$1</h3>');
-  html = html.replace(/^## (.+)$/gm,     '<h2>$1</h2>');
-  html = html.replace(/^# (.+)$/gm,      '<h1>$1</h1>');
-
-  // Horizontal rule
-  html = html.replace(/^---+$/gm, '<hr>');
-
-  // Blockquotes
-  html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+  // Phase 3: Block-level transforms
+  s = s.replace(/^######\s(.+)$/gm, '<h6>$1</h6>');
+  s = s.replace(/^#####\s(.+)$/gm,  '<h5>$1</h5>');
+  s = s.replace(/^####\s(.+)$/gm,   '<h4>$1</h4>');
+  s = s.replace(/^###\s(.+)$/gm,    '<h3>$1</h3>');
+  s = s.replace(/^##\s(.+)$/gm,     '<h2>$1</h2>');
+  s = s.replace(/^#\s(.+)$/gm,      '<h1>$1</h1>');
+  s = s.replace(/^---+$/gm, '<hr>');
+  s = s.replace(/^&gt;\s(.+)$/gm, '<blockquote>$1</blockquote>');
 
   // Unordered lists
-  html = html.replace(/((?:^[\*\-] .+\n?)+)/gm, block => {
+  s = s.replace(/((?:^[*\-] .+\n?)+)/gm, block => {
     const items = block.trim().split('\n')
-      .map(l => `<li>${l.replace(/^[\*\-] /, '')}</li>`).join('');
+      .map(l => `<li>${l.replace(/^[*\-] /, '')}</li>`).join('');
     return `<ul>${items}</ul>`;
   });
 
   // Ordered lists
-  html = html.replace(/((?:^\d+\. .+\n?)+)/gm, block => {
+  s = s.replace(/((?:^\d+\. .+\n?)+)/gm, block => {
     const items = block.trim().split('\n')
       .map(l => `<li>${l.replace(/^\d+\. /, '')}</li>`).join('');
     return `<ol>${items}</ol>`;
   });
 
-  // Inline: bold, italic, inline code, images, links
-  html = html.replace(/\*\*(.+?)\*\*/g,         '<strong>$1</strong>');
-  html = html.replace(/\*(.+?)\*/g,              '<em>$1</em>');
-  html = html.replace(/`([^`]+)`/g,              '<code>$1</code>');
-  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img alt="$1" src="$2">');
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g,  '<a href="$2" target="_blank" rel="noopener">$1</a>');
+  // Phase 4: Inline transforms
+  s = s.replace(/\*\*(.+?)\*\*/g,            '<strong>$1</strong>');
+  s = s.replace(/\*(.+?)\*/g,                '<em>$1</em>');
+  s = s.replace(/`([^`]+)`/g,                '<code>$1</code>');
+  s = s.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img alt="$1" src="$2">');
+  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g,  '<a href="$2" target="_blank" rel="noopener">$1</a>');
 
-  // Paragraphs
-  const blockTags = ['<h1','<h2','<h3','<h4','<h5','<h6','<ul','<ol','<pre','<hr','<blockquote','</ul','</ol','</pre','</blockquote'];
-  const lines = html.split('\n');
+  // Phase 5: Paragraphs — placeholders count as block elements
+  const blockTags = ['<h1','<h2','<h3','<h4','<h5','<h6',
+    '<ul','<ol','<pre','<hr','<blockquote',
+    '</ul','</ol','</pre','</blockquote',
+    '\x00BLOCK'];
+  const lines = s.split('\n');
   const out = [];
   let inBlock = false;
 
@@ -98,9 +106,63 @@ function mdToHtml(md) {
     }
   }
 
-  return out.map(line =>
+  s = out.map(line =>
     (line.startsWith('<p>') && !line.endsWith('</p>')) ? line + '</p>' : line
   ).join('\n');
+
+  // Phase 6: Restore code blocks
+  s = s.replace(/\x00BLOCK(\d+)\x00/g, (_, i) => codeBlocks[+i]);
+
+  return s;
+}
+
+/* -------------------------------------------------------
+   Code block enhancer
+   Wraps every <pre> inside post content with a header bar
+   showing the language label and a copy button.
+------------------------------------------------------- */
+function enhanceCodeBlocks(container) {
+  container.querySelectorAll('pre').forEach(pre => {
+    if (pre.closest('.post-code-block')) return; // already enhanced
+
+    const codeEl = pre.querySelector('code');
+
+    // Detect language from class e.g. lang-js, language-python
+    const langClass = Array.from((codeEl || pre).classList)
+      .find(c => c.startsWith('lang-') || c.startsWith('language-'));
+    const lang = langClass
+      ? langClass.replace(/^lang-|^language-/, '').replace('text', '')
+      : '';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'post-code-block';
+
+    const header = document.createElement('div');
+    header.className = 'post-code-header';
+
+    const langLabel = document.createElement('span');
+    langLabel.className = 'post-code-lang';
+    langLabel.textContent = lang || 'code';
+
+    const copyBtn = document.createElement('button');
+    copyBtn.className = 'post-code-copy';
+    copyBtn.textContent = 'copy';
+    copyBtn.addEventListener('click', () => {
+      const text = (codeEl || pre).innerText;
+      navigator.clipboard.writeText(text).then(() => {
+        copyBtn.textContent = 'copied!';
+        copyBtn.style.color = 'var(--green)';
+        setTimeout(() => { copyBtn.textContent = 'copy'; copyBtn.style.color = ''; }, 1800);
+      }).catch(() => {});
+    });
+
+    header.appendChild(langLabel);
+    header.appendChild(copyBtn);
+
+    pre.parentNode.insertBefore(wrapper, pre);
+    wrapper.appendChild(header);
+    wrapper.appendChild(pre);
+  });
 }
 
 /* -------------------------------------------------------
@@ -324,16 +386,27 @@ async function fetchPosts() {
 
         const tags = (post.tags || []).map(t => `<span class="tag">${t}</span>`).join('');
 
+        const authorDisplay = post.author
+          ? `<span class="meta-author">${post.author}</span>`
+          : `<span class="meta-author">sarveshbhatnagar</span>`;
+
+        const sourceAttrib = post.author && post.source
+          ? `<div class="post-source-attrib">
+               Originally published on <a href="${post.source}" target="_blank" rel="noopener noreferrer">${new URL(post.source).hostname}</a>
+             </div>`
+          : '';
+
         container.innerHTML = `
             <div class="post-meta-bar">
               <div class="post-meta-info">
                 <span class="meta-date">// ${formatDate(post.date)}</span>
-                <span class="meta-author">sarveshbhatnagar</span>
+                ${authorDisplay}
               </div>
               <div class="tags">${tags}</div>
             </div>
             <div class="post-content fade-in">
               <h1>${post.title}</h1>
+              ${sourceAttrib}
               ${bodyHtml}
             </div>
             <div style="margin-top:var(--space-lg);">
@@ -343,6 +416,7 @@ async function fetchPosts() {
 
       if (hasInlinePostBody(post)) {
         renderPostBody(post.content);
+        enhanceCodeBlocks(container);
         return;
       }
 
@@ -352,7 +426,7 @@ async function fetchPosts() {
           if (!res.ok) throw new Error(`Could not load ${filename} (HTTP ${res.status})`);
           return res.text();
         })
-        .then(md => renderPostBody(mdToHtml(md)));
+        .then(md => { renderPostBody(mdToHtml(md)); enhanceCodeBlocks(container); });
     })
     .catch(err => {
       container.innerHTML = `

--- a/proxy_server.py
+++ b/proxy_server.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Local CORS proxy for blog-import.js
+Usage: python3 proxy_server.py
+
+Listens on http://localhost:8002
+Accepts: GET /proxy?url=<encoded-url>
+Returns: the fetched HTML with CORS headers set
+"""
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.request import urlopen, Request
+from urllib.parse import parse_qs, urlparse, unquote
+import urllib.error
+import ssl
+import sys
+
+# macOS ships Python without system cert access; skip verification for this local dev proxy.
+SSL_CTX = ssl.create_default_context()
+SSL_CTX.check_hostname = False
+SSL_CTX.verify_mode = ssl.CERT_NONE
+
+PORT = 8002
+
+HEADERS = {
+    'User-Agent': (
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+        'AppleWebKit/537.36 (KHTML, like Gecko) '
+        'Chrome/124.0.0.0 Safari/537.36'
+    ),
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.9',
+}
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._cors()
+        self.end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path != '/proxy':
+            self.send_error(404, 'Use /proxy?url=<url>')
+            return
+
+        params = parse_qs(parsed.query)
+        target = params.get('url', [None])[0]
+        if not target:
+            self.send_error(400, 'Missing url parameter')
+            return
+
+        target = unquote(target)
+
+        try:
+            req = Request(target, headers=HEADERS)
+            with urlopen(req, timeout=20, context=SSL_CTX) as resp:
+                content = resp.read()
+                content_type = resp.headers.get('Content-Type', 'text/html; charset=utf-8')
+
+            self.send_response(200)
+            self.send_header('Content-Type', content_type)
+            self.send_header('Content-Length', str(len(content)))
+            self._cors()
+            self.end_headers()
+            self.wfile.write(content)
+
+        except urllib.error.HTTPError as e:
+            self.send_error(e.code, 'Target returned: ' + str(e.reason))
+        except urllib.error.URLError as e:
+            self.send_error(502, 'Could not reach target: ' + str(e.reason))
+        except Exception as e:
+            self.send_error(500, str(e))
+
+    def _cors(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', '*')
+
+    def log_message(self, fmt, *args):
+        # Only print errors
+        if args and str(args[1]) not in ('200', '204'):
+            print(f'[proxy] {self.address_string()} {fmt % args}', file=sys.stderr)
+
+
+if __name__ == '__main__':
+    server = HTTPServer(('localhost', PORT), ProxyHandler)
+    print(f'CORS proxy running → http://localhost:{PORT}/proxy?url=<url>')
+    print('Press Ctrl+C to stop.')
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print('\nStopped.')


### PR DESCRIPTION
## Summary

- **Import from URL** — paste any article URL into `write.html`; Medium URLs are routed through `scribe.rip` to bypass Cloudflare, other sites go through a local Python CORS proxy (`proxy_server.py`) with public proxy fallback
- **Publish to GitHub** — one-click publish directly to `posts.json` via the GitHub Contents API using a PAT stored in localStorage; stores inline HTML for crawler/SEO compatibility
- **Author attribution** — original author and source URL fields auto-populated on import, rendered in the post viewer with a source link
- **Code block rendering** — fixed `mdToHtml` to extract code blocks as placeholders before any transforms (prevents heading/list rules from corrupting code content); `enhanceCodeBlocks()` adds language badge + copy button to every `<pre>` in the post viewer

## Test plan

- [ ] Run `python3 proxy_server.py` and `python3 -m http.server 8001`
- [ ] Open `http://localhost:8001/blog/write.html`
- [ ] Import a Medium URL and verify title, author, source, and code blocks populate correctly
- [ ] Add a GitHub PAT (fine-grained, `contents: write` on this repo) and publish a post
- [ ] Verify the post appears live on the blog within ~30 seconds
- [ ] View a post with code blocks and confirm language badge and copy button work

🤖 Generated with [Claude Code](https://claude.com/claude-code)